### PR TITLE
feature: add keyboard shortcut

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,7 @@ joplin.plugins.register({
 		});
 
 		joplin.views.toolbarButtons.create("highlight", "highlight", ToolbarButtonLocation.EditorToolbar);
+		// Add a menu entry, allowing the ability to assign a keyboard shortcut
+		joplin.views.menuItems.create('highlight', 'highlight', MenuItemLocation.Edit, { accelerator: 'CmdOrCtrl+H' });
 	},
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from 'api';
-import { ContentScriptType, ToolbarButtonLocation } from 'api/types';
+import { MenuItemLocation, ContentScriptType, ToolbarButtonLocation } from 'api/types';
 
 joplin.plugins.register({
 	onStart: async function() {
@@ -14,8 +14,8 @@ joplin.plugins.register({
 			}
 		});
 
-		joplin.views.toolbarButtons.create("highlight", "highlight", ToolbarButtonLocation.EditorToolbar);
+		joplin.views.toolbarButtons.create("highlightToolbar", "highlight", ToolbarButtonLocation.EditorToolbar);
 		// Add a menu entry, allowing the ability to assign a keyboard shortcut
-		joplin.views.menuItems.create('highlight', 'highlight', MenuItemLocation.Edit, { accelerator: 'CmdOrCtrl+H' });
+		joplin.views.menuItems.create('highlightMenu', 'highlight', MenuItemLocation.Edit, { accelerator: 'CmdOrCtrl+H' });
 	},
 });


### PR DESCRIPTION
Creates a keyboard shortcut and defaults it to `Ctrl+H`. Resolves #5.

Tested on:
```
Joplin 2.8.8 (dev, linux)

Client ID: 7d5e9a939c604cb9bf6fbbefa7fc22ce
Sync Version: 3
Profile Version: 41
Keychain Supported: No

Revision: c2a6a13
```